### PR TITLE
Multi page form

### DIFF
--- a/hifireg/registration/forms.py
+++ b/hifireg/registration/forms.py
@@ -1,7 +1,28 @@
 from django.forms import ModelForm
+from django import forms
 from .models import Registration
+from .validators import validate_agree
 
-class RegistrationForm(ModelForm):
+class policy_form(ModelForm):
     class Meta:
         model = Registration
-        fields = ['agree_to_coc','allergens_severe']
+        fields = ['agree_to_coc', 'allergens_severe']
+
+    def formtype(self):
+        return 'policy_form'
+
+class accessibility_form(ModelForm):
+    class Meta:
+        model = Registration
+        fields = ['allergens_severe']
+
+    def formtype(self):
+        return 'accessibility_form'
+
+class tmpedit(forms.Form):
+    index = forms.IntegerField(label='Entry:', initial=1, min_value=1)
+    def __init__(self, *args, **kwargs):
+        maxindex = kwargs.pop('maxindex', None)
+        super(tmpedit, self).__init__(*args, **kwargs)
+        if maxindex:
+            self.fields['index'] = forms.IntegerField(label='Entry:', initial=0, min_value=0, max_value=maxindex)

--- a/hifireg/registration/forms.py
+++ b/hifireg/registration/forms.py
@@ -19,10 +19,11 @@ class accessibility_form(ModelForm):
     def formtype(self):
         return 'accessibility_form'
 
-class tmpedit(forms.Form):
-    index = forms.IntegerField(label='Entry:', initial=1, min_value=1)
-    def __init__(self, *args, **kwargs):
-        maxindex = kwargs.pop('maxindex', None)
-        super(tmpedit, self).__init__(*args, **kwargs)
-        if maxindex:
-            self.fields['index'] = forms.IntegerField(label='Entry:', initial=0, min_value=0, max_value=maxindex)
+# class tmpedit(forms.Form):
+#     index = forms.IntegerField(label='Entry:', initial=1, min_value=1)
+#     def __init__(self, *args, **kwargs):
+#         maxindex = kwargs.pop('maxindex', None)
+#         super(tmpedit, self).__init__(*args, **kwargs)
+#         if maxindex:
+#             self.fields['index'] = forms.IntegerField(label='Entry:', initial=0, min_value=0, max_value=maxindex)
+

--- a/hifireg/registration/helpers/router.py
+++ b/hifireg/registration/helpers/router.py
@@ -1,0 +1,76 @@
+from ..forms import *
+
+
+# router
+# serves up next modelform based on registration object data, and user input
+# has two types of subroutine for each modelform: route and prep.
+# route determines which page to show next
+# prep returns the new modelform and appropriate navigation button layout
+def router(*args):
+    f = None
+
+    # if arguments are passed, split the registration object and navigation direction
+    if args:
+        reg_obj = args[0]
+        current_page = args[1]
+        direction = args[2]
+        if 'policy_form' in current_page:
+            f = route_policy(reg_obj, direction)
+        elif 'accessibility_form' in current_page:
+            f = route_accessibility(reg_obj, direction)
+
+    # if no arguments are passed, assume we are starting a new form.
+    else:
+        f = policy_form()  # currently, the first page is policy_form, but that will change.
+
+    # update current page info to reflect new modelform type
+    current_page = f.formtype()
+
+    # determine which navigation buttons to show on this page
+    if 'policy_form' in current_page:
+        context = {'next': 'next'}
+    elif 'accessibility_form' in current_page:
+        context = {'prev': 'prev', 'submit': 'submit'}
+    else:
+        context = {'prev': 'prev', 'next': 'next'}
+    context['form'] = f
+    context['current_page'] = current_page
+    return context
+
+
+def route_policy(reg_obj, direction):
+    if 'next' in direction:
+        f = accessibility_form(instance=reg_obj)
+        return f
+
+
+def route_accessibility(reg_obj, direction):
+    if 'prev' in direction:
+        f = policy_form(instance=reg_obj)
+        return f
+
+
+# modelform selector
+# Identifies which modelform needs to be saved based on the request.POST data
+def mf_sel(request_post, current_page, *args):
+    instance = None
+    if args:
+        instance = args[0]
+
+    # Instantiate correct modelform object using appropriate model instance and populate it with post data
+    # We need the name of a field that is unique to establish which modelform to use.
+    # Since we do not repeat fields during registration, any field will do.
+    # policy_form() instantiates a modelform of type policy_form.
+    # Once instantiated, the object has fields.
+    # policy_form().fields returns a dictionary of the field names and fields.
+    # We are interested in the names of the fields, so we take the keys of the dictionary and omit the values:
+    # policy_form().fields.keys()
+    # iter() turns those keys into an array through which we can iterate
+    # next() iterates once, to the first object, which is the name of the first field in the modelform
+    if next(iter(policy_form().fields.keys())) in request_post:
+        f = policy_form(request_post, instance=instance)
+    elif next(iter(accessibility_form().fields.keys())) in request_post:
+        f = accessibility_form(request_post, instance=instance)
+    elif next(iter(tmpedit().fields.keys())) in request_post:
+        f = tmpedit(request_post, instance=instance)
+    return f

--- a/hifireg/registration/models.py
+++ b/hifireg/registration/models.py
@@ -3,6 +3,7 @@ from django.contrib.sessions.models import Session
 from django.db import transaction, IntegrityError
 from django.core.exceptions import SuspiciousOperation
 from django.db.models import Sum
+from .validators import validate_agree
 
 class UserSession(models.Model):
     DjangoSession = models.ForeignKey(Session, on_delete=models.CASCADE, null=True)

--- a/hifireg/registration/templates/registration/confirmation.html
+++ b/hifireg/registration/templates/registration/confirmation.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>High-Fidelity Fusion Registration Form</title>
+</head>
+<body>
+    <h1>High-Fidelity Fusion Registration Form</h1>
+    <h2>Registration Confirmed!</h2>
+    <p>Thank you for submitting your registration</p>
+    <a href="{% url 'index' %}"><button type="button">Return</button></a>
+</body>
+</html>

--- a/hifireg/registration/templates/registration/index.html
+++ b/hifireg/registration/templates/registration/index.html
@@ -2,10 +2,13 @@
 
 <a href="registration_form"><button type="button">New Reg</button></a>
 
+<!--
+Form returns numeric input for selecting Registration Object to edit
 {% if maximum > 0 %}
     <form action="{% url 'tmp_edit' %}" method="POST">
         {% csrf_token %}
         {{ form }}
-        <input type="submit" id="Edit" name="Edit" value="Edit Reg">
+        <input type="submit" id="edit" name="edit" value="Edit Reg">
     </form>
 {% endif %}
+-->

--- a/hifireg/registration/templates/registration/index.html
+++ b/hifireg/registration/templates/registration/index.html
@@ -1,1 +1,11 @@
-<h1>hello world template</h1>
+<h1>hello world template</h1><br>
+
+<a href="registration_form"><button type="button">New Reg</button></a>
+
+{% if maximum > 0 %}
+    <form action="{% url 'tmp_edit' %}" method="POST">
+        {% csrf_token %}
+        {{ form }}
+        <input type="submit" id="Edit" name="Edit" value="Edit Reg">
+    </form>
+{% endif %}

--- a/hifireg/registration/templates/registration/reg_form.html
+++ b/hifireg/registration/templates/registration/reg_form.html
@@ -13,21 +13,26 @@
 
         <!-- <title> sets the title of your page, which is the title that appears in the browser tab the page is loaded in, and is used to describe the page when you bookmark/favorite it. -->
         <title>
+            High-Fidelity Fusion Registration Form
         </title>
 
     </head>
 
     <!-- body - wraps all content shown to page users -->
     <body>
-        <form action="{% url 'submit' %}" method="post">
+        <h1>High-Fidelity Fusion Registration Form</h1>
+        <form action="{% url 'registration_form' %}" method="post">
             {% csrf_token %}
-            <h1>High-Fidelity Fusion Registration Form</h1>
-            <h2>Code of Conduct</h2>
-            COC full text. Lorem Ipsum...
-            <br><br>
-            {{registration_form}}
-            <br><br>
-            <input type="submit">
+            {{form}}
+            {% if prev %}
+            <input type="submit", name="prev", value="Previous">
+            {% endif %}
+            {% if next %}
+            <input type="submit", name="next", value="Next">
+            {% endif %}
+            {% if submit %}
+            <input type="submit", name="submit">
+            {% endif %}
         </form>
     </body>
 </html>

--- a/hifireg/registration/urls.py
+++ b/hifireg/registration/urls.py
@@ -5,9 +5,7 @@ from . import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('login', views.login, name='login'),
-    path('form', views.form, name='form'),
     path('registration_form', views.registration_form_view, name='registration_form'),
-    path('submit', views.submit, name='submit'),
-    path('tmp_edit', views.tmp_edit, name="tmp_edit"),
+    # path('tmp_edit', views.tmp_edit, name="tmp_edit"),
     path('confirmation', views.confirmation, name="confirmation"),
 ]

--- a/hifireg/registration/urls.py
+++ b/hifireg/registration/urls.py
@@ -5,6 +5,9 @@ from . import views
 urlpatterns = [
     path('', views.index, name='index'),
     path('login', views.login, name='login'),
-    path('form',views.form, name='form'),
-    path('submit',views.submit,name='submit')
+    path('form', views.form, name='form'),
+    path('registration_form', views.registration_form_view, name='registration_form'),
+    path('submit', views.submit, name='submit'),
+    path('tmp_edit', views.tmp_edit, name="tmp_edit"),
+    path('confirmation', views.confirmation, name="confirmation"),
 ]

--- a/hifireg/registration/validators.py
+++ b/hifireg/registration/validators.py
@@ -1,0 +1,7 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
+
+
+def validate_agree(value):
+    if value is not True:
+        raise ValidationError(_('You must agree to proceed.'))

--- a/hifireg/registration/views.py
+++ b/hifireg/registration/views.py
@@ -7,10 +7,9 @@ from .helpers.router import *
 
 
 def index(request):
-    maxindex = Registration.objects.count()-1
-    form = tmpedit(maxindex=maxindex)
-    print(form)
-    return render(request, 'registration/index.html', {'maximum': maxindex, 'form': form})
+    # maxindex = Registration.objects.count()-1
+    # f = tmpedit(maxindex=maxindex)
+    return render(request, 'registration/index.html')  # , {'maximum': maxindex, 'form': f}) This code is related to tmpedit
 
 
 def login(request):
@@ -27,25 +26,19 @@ def login(request):
     return render(request, 'registration/index.html', {'form': f})
 
 
-def tmp_edit(request):
-    if request.method == 'POST':
-        form = tmpedit(request.POST)
-        if form.is_valid():
-            cd = form.cleaned_data
-            dbindex = cd.get('index')
-            reg = Registration.objects.all()[dbindex]
-            f = policy_form(instance=reg)
-            context = {'form': f, 'submit': 'submit'}
-            return render(request, 'registration/reg_form.html', context)
-        else:
-            print('it broke')
-            return redirect('login')
-
-
-def form(request):
-    f = policy_form()
-    context = {'form': f}
-    return render(request, 'registration/reg_form.html', context)
+# def tmp_edit(request):
+#     if request.method == 'POST':
+#         form = tmpedit(request.POST)
+#         if form.is_valid():
+#             cd = form.cleaned_data
+#             dbindex = cd.get('index')
+#             reg = Registration.objects.all()[dbindex]
+#             f = policy_form(instance=reg)
+#             context = {'form': f, 'submit': 'submit'}
+#             return render(request, 'registration/reg_form.html', context)
+#         else:
+#             print('it broke')
+#             return redirect('login')
 
 
 def registration_form_view(request):
@@ -101,17 +94,6 @@ def registration_form_view(request):
     else:
         context = router()
         request.session['current_page'] = context['current_page']
-        return render(request, 'registration/reg_form.html', context)
-
-
-def submit(request):
-    print(request.POST)
-    f = policy_form(request.POST)
-    if f.is_valid():
-        f.save()
-        return redirect('confirmation')
-    else:
-        context = {'form': f}
         return render(request, 'registration/reg_form.html', context)
 
 

--- a/hifireg/registration/views.py
+++ b/hifireg/registration/views.py
@@ -3,11 +3,15 @@ from django.http import HttpResponse
 from django.contrib import messages
 from django.contrib.auth.forms import UserCreationForm
 from django.shortcuts import redirect
-from .forms import RegistrationForm
+from .helpers.router import *
 
 
 def index(request):
-    return render(request, 'registration/index.html')
+    maxindex = Registration.objects.count()-1
+    form = tmpedit(maxindex=maxindex)
+    print(form)
+    return render(request, 'registration/index.html', {'maximum': maxindex, 'form': form})
+
 
 def login(request):
     if request.method == 'POST':
@@ -20,17 +24,96 @@ def login(request):
     else:
         f = UserCreationForm()
 
-    return render(request, 'registration/login.html', {'form': f})
+    return render(request, 'registration/index.html', {'form': f})
+
+
+def tmp_edit(request):
+    if request.method == 'POST':
+        form = tmpedit(request.POST)
+        if form.is_valid():
+            cd = form.cleaned_data
+            dbindex = cd.get('index')
+            reg = Registration.objects.all()[dbindex]
+            f = policy_form(instance=reg)
+            context = {'form': f, 'submit': 'submit'}
+            return render(request, 'registration/reg_form.html', context)
+        else:
+            print('it broke')
+            return redirect('login')
+
 
 def form(request):
-    f = RegistrationForm()
-    context = {'registration_form' : f}
-    return render(request,'registration/form.html', context)
+    f = policy_form()
+    context = {'form': f}
+    return render(request, 'registration/reg_form.html', context)
+
+
+def registration_form_view(request):
+    reg_inst_update = None
+
+    if request.method == 'POST':
+        # print('request.POST:')
+        # print(request.POST)
+        # see if there is saved data for this registration. If there is, get it. If not, record the
+        try:
+            instance = Registration.objects.get(id=request.session['reg_id'])
+            f = mf_sel(request.POST, request.session['current_page'], instance)
+        except KeyError:
+            f = mf_sel(request.POST, request.session['current_page'])
+            reg_inst_update = True
+        # print('modelform populated with form data:')
+        # print(f)
+        if f.is_valid():
+            # save form data
+            reg_obj = f.save()  # result is registration object
+            print('registration instance:')
+            print(reg_obj)
+
+            # oneshot: preserve registration id in session
+            if reg_inst_update:
+                request.session['reg_id'] = reg_obj.id
+
+            print('registration id:')
+            print(request.session['reg_inst'])
+
+            # find navigation input in form data
+            direction = None
+            if 'next' in request.POST:
+                direction = 'next'
+            elif 'prev' in request.POST:
+                direction = 'prev'
+            elif 'submit' in request.POST:
+                direction = 'submit'
+            # elif direction is None:
+
+            # if submitted, route to confirmation. Otherwise, route to next page.
+            if 'submit' in direction:
+                del request.session['reg_id']
+                return redirect('confirmation')
+            else:
+                context = router(reg_obj, request.session['current_page'], direction)
+                request.session['current_page'] = context['current_page']
+                return render(request, 'registration/reg_form.html', context)
+        else:
+            print('it bork')
+            print(f.errors)
+            return redirect('index')
+    else:
+        context = router()
+        request.session['current_page'] = context['current_page']
+        return render(request, 'registration/reg_form.html', context)
+
 
 def submit(request):
-    f = RegistrationForm(request.POST or None)
+    print(request.POST)
+    f = policy_form(request.POST)
     if f.is_valid():
         f.save()
-        return render(request,'registration/index.html')
+        return redirect('confirmation')
     else:
-        return render(request, 'registration/form.html'),{'error_message': "Sucks to suck."}
+        context = {'form': f}
+        return render(request, 'registration/reg_form.html', context)
+
+
+def confirmation(request):
+    return render(request, 'registration/confirmation.html')


### PR DESCRIPTION
Creates basis for multipage form:

- Each group of fields displayed to a user on one page is its own ModelForm
- All ModelForms use the same model (Registration)
- All ModelForms are displayed from the same view - this eliminates duplicate view code
- Creates router to serve next form based on ModelForms, hardcoded logic, and user input.
- Branching logic (currently trivial) may get fairly intense. To prepare for that, routing from each ModelForm to the next gets its own subroutine.
- Creates ModelForm selector (mf_sel) to identify which ModelForm generated the post request and instantiate that instance for saving.
- Toyed with editing database entries using tmpedit form. It provides potentially useful model code for future functionality. For now, it is commented out.
- Index Template links to start of registration form
- registration template displays navigation buttons with appropriate names and functions.
- Created confirmation template