### PR TITLE
Added checkbox toggle when click on product-card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ package-lock.json
 css/
 db.sqlite3
 migrations/
+
+.DS_Store

--- a/hifireg/registration/static/scripts/ticket_selection.js
+++ b/hifireg/registration/static/scripts/ticket_selection.js
@@ -1,3 +1,28 @@
+//product-card clicks can togggle checkbox
+$('.product-card').on('click', function(e) {
+  //if this is not a checkbox card, move on
+  var checkBox = $(this).find('.product-checkbox');
+  if (checkBox.length === 0) {
+    return;
+  }
+
+  //if checkbox clicked: ignore and let change handler handle it 
+  // prevents error that when checked the card is immeidately auto-unchecked
+  if (e.target === checkBox[0]) {
+    return;
+  }
+  
+  //Making no action for checkbox when user clicks "Details" carrot icon
+  if (e.target.tagName.toLowerCase() === 'details') {
+    return;
+  }
+  
+  //if you click on the card outside the checkbox, 
+  //toggle the checkbox and trigger change event
+  checkBox.click();
+});
+
+//When a checkbox toggles off or on, run this code
 $(".product-checkbox").change(function() {
   var thisCheckBox = this;
   var parent = $(thisCheckBox).parent();


### PR DESCRIPTION
- Added a quick gitignore bit for my mac auto making DS_store files
- Made it so product-cards can toggle the checkbox input on single item cards
- Disabled checkbox action when clicking on Details word/Carrot icon near the word
- Added code to check if a checkbox card or multi-select card so the code only runs on check-box cards

Asana Task: https://app.asana.com/0/1157808567895197/1175032686658026/f