### PR TITLE
Fixed product_card columns

### DIFF
--- a/hifireg/registration/templates/registration/product_card.html
+++ b/hifireg/registration/templates/registration/product_card.html
@@ -1,5 +1,5 @@
 {% load special_sauce %}
-<div class="column">
+<div class="column is-half">
 <div class="">
   <div data-product="{{product.id}}" data-slots="{{product.slots}}" data-max="{{product.max_quantity}}"
        class="box product-card {{product.slotClasses}} {{product.conflictClasses}}

--- a/hifireg/registration/templates/registration/register_selection.html
+++ b/hifireg/registration/templates/registration/register_selection.html
@@ -7,19 +7,26 @@
 {% block content %}
 <p>Choose your {{section}}!</p>
 {% for category in categories %}
-<h3 class="title">{{category.name}}</h3>
+  <h3 class="title">{{category.name}}</h3>
+  <!-- Starting slots For category {{category.name}}  -->
   {% for slot in category.slots %}
-  <h4 class="title is-4">{{slot.name}}</h4>
-<div class="">
-    {% for product in slot.products %}
-        {% include 'registration/product_card.html' %}
-      {% endfor %}
+    <h4 class="title is-4">{{slot.name}}</h4>
+    <div class="columns is-multiline">
+      <!-- Starting products For category {{category.name}} slot {{slot.name}} -->
+      {% for product in slot.products %}
+      {% include 'registration/product_card.html' %}
     {% endfor %}
+    </div>
+  {% endfor %}
+  
+  <!-- Starting products For category {{category.name}}  -->
+  <div class="columns is-multiline">
   {% for product in category.products %}
     {% include 'registration/product_card.html' %}
   {% endfor %}
   </div>
 {% endfor %}
+
 <form method="post">
   {% csrf_token %}
 

--- a/hifireg/registration/templates/registration/register_selection.html
+++ b/hifireg/registration/templates/registration/register_selection.html
@@ -14,8 +14,8 @@
     <div class="columns is-multiline">
       <!-- Starting products For category {{category.name}} slot {{slot.name}} -->
       {% for product in slot.products %}
-      {% include 'registration/product_card.html' %}
-    {% endfor %}
+        {% include 'registration/product_card.html' %}
+      {% endfor %}
     </div>
   {% endfor %}
   


### PR DESCRIPTION
- Shifted code outside a div that was causing a bug, needed it's own .columns div to behave correctly
- Re-added .columns class to div in "register_selection.html"
- Added a new class to .columns and a new class to .column (in "product_card.html") to manage 2 column width page that wraps to a new line if more than 2 product_cards called. 
- This change impacted All pages w/cards in Register section of site (Merch, Dance Passes, Class Tickets)
- Fixed indentation and added html comments to template for code clarity

## BEFORE: 
![image](https://user-images.githubusercontent.com/36306993/82739451-70ffff80-9cf4-11ea-90c5-65a23af4211f.png)

## AFTER: 
![image](https://user-images.githubusercontent.com/36306993/82739418-37c78f80-9cf4-11ea-8c18-7725d2852006.png)
