### PR TITLE
Div Style Consistency for All Registration Pages

### DIFF
--- a/hifireg/registration/templates/registration/register_selection.html
+++ b/hifireg/registration/templates/registration/register_selection.html
@@ -4,7 +4,7 @@
 {% include 'registration/countdown_widget.html' %}
 {% endblock %}
 
-{% block content %}
+{% block card_content %}
 <p>Choose your {{section}}!</p>
 {% for category in categories %}
   <h3 class="title">{{category.name}}</h3>


### PR DESCRIPTION
- Existing "box shadow" feature (originally seen on Policy page) now encompasses Buttons & Title on **every** Reg page for consistency:

<img width="980" alt="Screen Shot 2020-05-29 at 4 44 37 PM" src="https://user-images.githubusercontent.com/36306993/83313619-e1fb5780-a1cb-11ea-8fa4-1fc0cf23ae79.png">
