### PR TITLE
Task 3 of 5 | Payment & Stripe | JS & Redirects

### DIFF
--- a/hifireg/registration/static/scripts/checkout.js
+++ b/hifireg/registration/static/scripts/checkout.js
@@ -1,0 +1,20 @@
+// when click checkout button
+$("#checkoutButton").on("click", function(e){
+    e.preventDefault();
+    // make request to new_checkout url
+    $.get("/registration/payment/new_checkout", function(data, status){
+        // create instance of Stripe 
+        var stripe = Stripe(data.public_key);
+        // use Stripe to redirect to Checkout
+        stripe.redirectToCheckout({
+            sessionId: data.session_id
+          }).then(function (result) {
+            console.log(result);
+            // From Documentation: If `redirectToCheckout` fails due to a browser or network
+            // error, display the localized error message to your customer
+            // using `result.error.message`.
+          });
+    });
+});
+
+

--- a/hifireg/registration/templates/registration/payment.html
+++ b/hifireg/registration/templates/registration/payment.html
@@ -17,9 +17,13 @@
 
     <div class="control">
         <button type="submit" name='previous' class="button is-link">Previous</button>
-        <button type="submit" name='submit' class="button is-link">Checkout</button>
+        <button id="checkoutButton" type="submit" name='submit' class="button is-link">Checkout</button>
     </div>
 
 </form>
 
+{% load static %}
+<script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
+<script src="https://js.stripe.com/v3/"></script>
+<script src="{% static 'scripts/checkout.js' %}"></script>
 {% endblock %}

--- a/hifireg/registration/views/registration.py
+++ b/hifireg/registration/views/registration.py
@@ -290,9 +290,7 @@ class MakePaymentView(PolicyRequiredMixin, FunctionBasedView, View):
         if request.method == 'POST':
             if 'previous' in request.POST:
                 return redirect('payment_plan')
-            return redirect('payment_confirmation')
-        else:
-            return render(request, 'registration/payment.html', {'form': form})
+        return render(request, 'registration/payment.html', {'form': form})
 
 
 class NewCheckoutView(PolicyRequiredMixin, FunctionBasedView, View):
@@ -305,9 +303,9 @@ class NewCheckoutView(PolicyRequiredMixin, FunctionBasedView, View):
             reg_amount = 150000
 
             # urls for recieving redirects from Stripe
-            success_url = request.build_absolute_uri(reverse('payment_confirmation') + '?session_id={CHECKOUT_SESSION_ID}')
+            success_url = request.build_absolute_uri(reverse('payment_confirmation')) + '?session_id={CHECKOUT_SESSION_ID}'
             cancel_url = request.build_absolute_uri(reverse('make_payment'))
-            
+      
             try:
                 # Create new Checkout Session for the order
                 # Other optional params: https:#stripe.com/docs/api/checkout/sessions/create


### PR DESCRIPTION
**With this change:** HiFi Payment Page Checkout Button can redirect to Stripe for payment collection
- [x] Load Stripe JS Module into existing payment.html file
- [x] Fixed py code success_url to interpret session id correctly for success redirect
- [x] Created new JS file for Stripe code
- [x] Add JS Ajax to call the new checkout URL 
- [x] Use 'data' json key to redirect to Stripe
- [x] Make event handler JS for “purchase” button
- [x] Go to MakePaymentView and remove the redirect to "payment_confirmation" action (views/registration.py)
<img width="999" alt="Screen Shot 2020-06-20 at 9 31 47 PM" src="https://user-images.githubusercontent.com/36306993/85216863-bb4dbe00-b33e-11ea-8677-a8f98721ba8f.png">
