### PR TITLE
Post order Payment page for all other invoices

### DIFF
--- a/hifireg/registration/static/scripts/invoices.js
+++ b/hifireg/registration/static/scripts/invoices.js
@@ -1,0 +1,118 @@
+// this large anon function protects my "global variables on this page"
+(function() {
+  var selectAllCheckbox = document.querySelector("#selectAll");
+  var label = document.querySelector("#selectAllLabel");  
+  var invoiceCheckboxes = document.querySelectorAll("#invoiceTable input");
+  var payInvoicesButton = document.querySelector("#payInvoicesButton")
+
+  var selectAllText = "Select All Invoices";
+  var unselectAllText = "Unselect Invoices"
+
+  // toggle HTML for select all checkbox
+  selectAllCheckbox.onchange = function() {
+    if (selectAllCheckbox.checked === false) {
+      selectAll(false);
+      label.innerHTML = selectAllText;
+    } else {
+      label.innerHTML = unselectAllText;
+      selectAll(true);
+    }
+    updateTotal();
+  };
+
+  // logic for select/unselect all checkboxs on invoices.html
+  function selectAll(checked) {
+    for (var i = 0; i < invoiceCheckboxes.length; i++) {
+      if (invoiceCheckboxes[i].type == 'checkbox') {
+        invoiceCheckboxes[i].checked = checked;
+      }  
+    }
+  };
+
+  // catch logic for chronological due date pay requirement
+  function checkAllPriorInvoices(checkbox) {
+    var i = 0;
+    while (invoiceCheckboxes[i] !== checkbox) {
+      invoiceCheckboxes[i].checked = true;
+      i += 1;
+    }
+  };
+
+  function uncheckAllFutureInvoices(checkbox) {
+    var i = invoiceCheckboxes.length - 1;
+    while (invoiceCheckboxes[i] !== checkbox) {
+      invoiceCheckboxes[i].checked = false;
+      i -= 1;
+    }
+  };
+
+  // this dynamic query is called in several functions
+  function getCheckedCheckboxes() {
+    return document.querySelectorAll("#invoiceTable input:checked");
+  }
+
+  function onCheckboxChange(e) {
+    if (e.target.checked) {
+      checkAllPriorInvoices(e.target);
+    } else {
+      uncheckAllFutureInvoices(e.target);
+    }
+    var checkedCheckboxes = getCheckedCheckboxes();
+    if (checkedCheckboxes.length === invoiceCheckboxes.length) {
+      label.innerHTML = unselectAllText;
+      selectAllCheckbox.checked = true;
+    } else {
+      label.innerHTML = selectAllText;
+      selectAllCheckbox.checked = false;
+    }
+    updateTotal();
+  };
+
+  // sums up pay amount based on checked boxes
+  invoiceCheckboxes.forEach(function(checkbox){
+    checkbox.onchange = onCheckboxChange;
+  });
+  
+  function updateTotal() {
+    var amountDue = calculateTotalPaymentAmount();
+    document.querySelector("#amountDue").innerHTML = dollars(amountDue);
+    payInvoicesButton.disabled = amountDue === 0;
+  };
+
+  function calculateTotalPaymentAmount() {
+    var checkedCheckboxes = getCheckedCheckboxes();
+    var amount = 0;
+
+    checkedCheckboxes.forEach(function(checkbox){
+        amount += parseInt(checkbox.dataset.amount);
+    });
+    return amount;
+  };
+
+  // converts total amount to dollars at top of page
+  function dollars(value) {
+    value = value * 0.01;
+    value = value.toFixed(2);
+    return "$" + value;
+  };
+  
+  // AJAX (for brevity sake) request to Stripe API
+  payInvoicesButton.onclick = function(e){
+    e.preventDefault();
+    var amount = calculateTotalPaymentAmount();
+
+    $.get("/registration/invoices/pay?amount=" + amount, function(data, status){
+        var stripe = Stripe(data.public_key);
+       
+        stripe.redirectToCheckout({
+          sessionId: data.session_id
+        }).then(function (result) {
+          console.log(result);
+        });
+    });
+  };
+
+  updateTotal();
+})();
+
+

--- a/hifireg/registration/templates/registration/index.html
+++ b/hifireg/registration/templates/registration/index.html
@@ -9,6 +9,7 @@
 <div class="buttons">
     {% include "utils/button.html" with button=view.register_button %}
     {% include "utils/button.html" with button=view.account_button %}
+    {% include "utils/button.html" with button=view.invoices_button %}
 </div>
 
 {% endblock %}

--- a/hifireg/registration/templates/registration/invoices.html
+++ b/hifireg/registration/templates/registration/invoices.html
@@ -1,0 +1,62 @@
+{% extends "registration/base.html" %}
+{% load special_sauce %}
+
+{% block card_content %}
+
+{% if amount_paid %}
+<div class="message is-success">
+  <div class="message-header">
+    <p>Success!</p>
+  </div>
+  <div class="message-body">
+    Yay! You just paid {{ amount_paid|dollars }}!
+  </div>
+</div>
+{% endif %}
+
+<h2 class="is-size-4">Hi, {{ user.first_name }}!</h2>
+
+<div class="box">
+  <button id="payInvoicesButton" class="button is-success is-pulled-right">Pay Invoice(s)</button>
+  <h3 class="is-size-3">Make a Payment: <span id="amountDue"></span></h3>
+</div>
+<br>
+
+<p><em>Note: The invoice at the top of the list below must be paid prior or in addition to any following invoices</em></p>
+<br>
+
+
+<input type="checkbox" id="selectAll">
+<label id="selectAllLabel" for="selectAll">Select All Invoices</label>
+<div id="invoiceTable">
+  <table class="table is-hoverable">
+    <tr>
+      <th></th>
+      <th>Invoice ID</th>
+      <th>Amount</th>
+      <th>Due Date</th>
+    </tr>
+    
+    {% for invoice in unpaid_invoices %}
+    <tr>
+      <td>
+        {% if forloop.counter0 == 0 %}
+          <input type="checkbox" checked data-amount="{{ invoice.amount }}">
+        {% else %}
+          <input type="checkbox" data-amount="{{ invoice.amount }}">
+        {% endif %}
+      </td>
+      <td>{{ invoice.pk }}</td>
+      <td>{{ invoice.amount|dollars }}</td>
+      <td>{{ invoice.due_date|date:"SHORT_DATE_FORMAT" }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+</div>
+
+{% load static %}
+<script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
+<script src="https://js.stripe.com/v3/"></script>
+<script src="{% static 'scripts/invoices.js' %}"></script>
+
+{% endblock %}

--- a/hifireg/registration/urls.py
+++ b/hifireg/registration/urls.py
@@ -42,6 +42,11 @@ urlpatterns = [
     path('payment/new_checkout', views.NewCheckoutView.as_view(), name='new_checkout'),
     path('payment/confirmation/', views.PaymentConfirmationView.as_view(), name='payment_confirmation'),
 
+    # post-order invoices to be paid
+    path('invoices/', views.InvoicesView.as_view(), name='invoices'),
+    path('invoices/pay', views.PayInvoicesView.as_view(), name='pay_invoices'),
+    path('invoices/pay/success', views.PayInvoicesSuccessView.as_view(), name='pay_success'),
+
     # auth/account views (some are overridden in views)
     path('account/create/', views.CreateUserView.as_view(), name='create_user'),
     path('account/view/', views.ViewUserView.as_view(), name='view_user'),

--- a/hifireg/registration/views/stripe_helpers.py
+++ b/hifireg/registration/views/stripe_helpers.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+
+import stripe
+
+
+def create_stripe_checkout_session(amount, success_url, cancel_url):
+    """
+    Create a new Stripe checkout session and return the session id.
+    """
+    # configure Stripe w/secret API key
+    stripe.api_key = settings.STRIPE_SECRET_TEST_KEY
+
+    # Create new Checkout Session for the order
+    # Other optional params: https:#stripe.com/docs/api/checkout/sessions/create
+    checkout_session = stripe.checkout.Session.create(
+        success_url = success_url,
+        cancel_url = cancel_url,
+        payment_method_types = ['card'],
+        line_items = [{
+            'price_data': {
+                'currency': 'usd',
+                'product_data': {
+                    'name': 'HiFi Registration',
+                },
+                'unit_amount': amount,
+            },
+            'quantity': 1,
+        }],
+        mode = 'payment',
+    )
+    return checkout_session['id']
+
+
+def get_stripe_checkout_session_total(checkout_session_id):
+    """
+    Get the total amount paid for a Stripe checkout session.
+    """
+    stripe.api_key = settings.STRIPE_SECRET_TEST_KEY
+    line_items = stripe.checkout.Session.list_line_items(checkout_session_id)
+    total_amount = 0
+    for line_item in line_items['data']:
+        total_amount += line_item['amount_total']
+    return total_amount


### PR DESCRIPTION

A) New page accessible from the landing page. (30 min)
 ✔️DONE -- Button on Landing Page (html & on IndexView)
 ✔️DONE -- URL in urls.py
 ✔️DONE -- Class View added to other views on views/registration.py
 ✔️DONE -- create HTML template

B) Should have a list of unpaid invoices with a check box, amount and due date. The next due invoice should be checked by default. (2 hour)
✔️DONE -- Get the InvoicesView to load invoices from DB
✔️DONE -- Sort invoices by ascending due date in the InvoicesView
✔️DONE -- Add context to the empty dictionary in InvoicesView
✔️DONE -- Add Checkboxes to invoices.html
✔️DONE -- Add invoice rows to html 
✔️DONE -- Top invoice input box should be checked
✔️DONE -- used Filter special sauce for cent conversion to show dollar in the invoices.html

C) Somehow, we need to enforce that invoices are paid in order. (can only pay last if also paying first) Not sure what the UX for this should be. (1 hour)
✔️DONE -- I can check/uncheck any box. When I check a box, it also checks all previous boxes. When I uncheck a box, it also unchecks all following boxes.
✔️DONE -- if no boxes are checked, disable pay button (fail safe for ensure the first invoice is checked via all other logic)

D) Should have a Select/Unselect All checkbox above the list. (20 min)
✔️DONE -- Add "Select All" input, innerHMTL toggle to "Unselect All" when box is checked (create invoices.js)

E) At the top, should have a Make a Payment section with an autocalculated Amount (sum of checked invoices) and a Checkout button that's Stripe integrated. (3 hours)
✔️DONE -- Bordered div that contains: Title, Total Amount (selected), and Pay Invoice(s) Button
✔️DONE -- Write math on NEW .js file (or the one you created earlier in this task) to total checked invoices
✔️DONE-- JS code for Pay Invoice(s) Button
✔️DONE -- For button create NEW view (and New URL for it) (but duplicated) Stripe Integration - in views/registration.py create new class view PayInvoicesView (copy other stripe api code from NewCheckoutSessionView, the 1 product inline will be the JavaScript invoices sum-total

F) After checkout, redirect back to this page, with a success banner that displays the amount paid. (Suggested: use a url param for the amount to optionally display the banner if the param is present) (45 minutes)
✔️DONE -- Stripe redirects to success_url
✔️DONE -- Write (again) new code to capture stripe session ID tagged onto each payment id that was paid
✔️DONE -- Redirect to THIS payment page providing URL with added param indicating payment was successful 
✔️DONE -- Create banner display w/{{success - amount paid}} on the invoices.html 

G) ✔️DONE -- Use basic bulma CSS to make the html page look presentable (30 min DO LAST)

**Various Screenshots showing tasks:** 
<img width="1075" alt="Screen Shot 2020-07-05 at 2 00 34 PM" src="https://user-images.githubusercontent.com/36306993/86542351-ee10be00-bec9-11ea-975a-dda0c0a04f85.png">

<img width="382" alt="Screen Shot 2020-07-05 at 2 01 18 PM" src="https://user-images.githubusercontent.com/36306993/86542355-f7018f80-bec9-11ea-95d4-7ddfee935c67.png">

<img width="1054" alt="Screen Shot 2020-07-05 at 2 03 34 PM" src="https://user-images.githubusercontent.com/36306993/86542358-fc5eda00-bec9-11ea-983f-bf28cb7548d7.png">

