### PR TITLE
Password beta access page and logic

### DIFF
--- a/hifireg/hifireg/settings.py
+++ b/hifireg/hifireg/settings.py
@@ -52,6 +52,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'registration.middleware.RefreshSessions',
+    'registration.middleware.CheckBetaPassword',
 ]
 
 ROOT_URLCONF = 'hifireg.urls'
@@ -184,3 +185,6 @@ STRIPE_SECRET_TEST_KEY = os.getenv('STRIPE_SECRET_TEST_KEY')
 MAILCHIMP_API_KEY = os.getenv('MAILCHIMP_API_KEY')
 MAILCHIMP_USERNAME = os.getenv('MAILCHIMP_USERNAME')
 MAILCHIMP_LIST = os.getenv('MAILCHIMP_LIST')
+
+# Beta Site Password
+BETA_PASSWORD = os.getenv('BETA_PASSWORD')

--- a/hifireg/registration/forms/__init__.py
+++ b/hifireg/registration/forms/__init__.py
@@ -1,2 +1,2 @@
 from .user import AuthenticationForm, UserCreationForm, UserUpdateForm, PasswordChangeForm, SetPasswordForm
-from .registration import RegPolicyForm, RegVolunteerForm, RegVolunteerDetailsForm, RegMiscForm, RegCompCodeForm, RegDonateForm
+from .registration import BetaPasswordForm, RegPolicyForm, RegVolunteerForm, RegVolunteerDetailsForm, RegMiscForm, RegCompCodeForm, RegDonateForm

--- a/hifireg/registration/forms/registration.py
+++ b/hifireg/registration/forms/registration.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator, MaxValueValidator
@@ -6,6 +7,16 @@ from registration.models import CompCode, Order, Registration, Volunteer, CompCo
 
 
 YESNO = [(False, 'No'), (True, 'Yes')]
+
+
+class BetaPasswordForm(forms.Form):
+    beta_password = forms.CharField(widget=forms.PasswordInput)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        password = cleaned_data.get('beta_password')
+        if password != settings.BETA_PASSWORD:
+            raise forms.ValidationError('Beta password is not correct')
 
 
 class RegPolicyForm(forms.ModelForm):

--- a/hifireg/registration/middleware.py
+++ b/hifireg/registration/middleware.py
@@ -1,5 +1,9 @@
 from datetime import datetime
 
+from django.conf import settings
+from django.shortcuts import redirect
+from django.urls import resolve
+
 
 class RefreshSessions:
     def __init__(self, get_response):
@@ -7,6 +11,20 @@ class RefreshSessions:
 
     def __call__(self, request):
         request.session['last_touch'] = datetime.now().timestamp()
+
+        response = self.get_response(request)
+        return response
+
+
+class CheckBetaPassword:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        current_url = resolve(request.path_info).url_name
+        if not current_url == 'beta_login':
+            if not request.session.get('site_password') and settings.BETA_PASSWORD:
+                return redirect('beta_login')
 
         response = self.get_response(request)
         return response

--- a/hifireg/registration/templates/registration/beta_login.html
+++ b/hifireg/registration/templates/registration/beta_login.html
@@ -1,0 +1,12 @@
+{% extends "registration/base.html" %}
+{% load special_sauce %}
+
+{% block card_content %}
+
+<form method="POST">
+  {% csrf_token %}
+  {{ form.as_p }}
+  <input type="submit" value="Enter">
+</form>
+
+{% endblock %}

--- a/hifireg/registration/urls.py
+++ b/hifireg/registration/urls.py
@@ -15,6 +15,9 @@ urlpatterns = [
     #testing email:
     path('order/send_email', views.SendEmail.as_view(), name='send_email'),
 
+    # beta login url:
+    path('beta_login/', views.BetaLoginView.as_view(), name='beta_login'),
+
     # must have registration:
     path('register/', RedirectView.as_view(url=reverse_lazy('register_comp_code')), name='registration'), # redirects to registration creation view
     path('register/comp/', views.RegisterCompCodeView.as_view(), name='register_comp_code'),

--- a/hifireg/registration/views/registration.py
+++ b/hifireg/registration/views/registration.py
@@ -7,10 +7,11 @@ from django.http import JsonResponse
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.views.generic.base import TemplateView
+from django.views.generic.edit import FormView
 from django.views import View
 from datetime import datetime, timedelta
 
-from registration.forms import RegCompCodeForm, RegPolicyForm, RegDonateForm, RegVolunteerForm, RegVolunteerDetailsForm, RegMiscForm
+from registration.forms import BetaPasswordForm, RegCompCodeForm, RegPolicyForm, RegDonateForm, RegVolunteerForm, RegVolunteerDetailsForm, RegMiscForm
 
 from registration.models import CompCode, Order, ProductCategory, Registration, Volunteer, Product, APFund, Invoice, Payment, OrderItem
 from registration.models.helpers import with_is_paid
@@ -21,6 +22,17 @@ from .utils import SubmitButton, LinkButton
 from .helpers import get_context_for_product_selection
 from .stripe_helpers import create_stripe_checkout_session, get_stripe_checkout_session_total
 from .mailchimp_client import create_or_update_subscriber
+
+
+class BetaLoginView(FormView):
+    template_name = 'registration/beta_login.html'
+    form_class = BetaPasswordForm
+    success_url = '/'
+
+    def form_valid(self, form):
+        self.request.session['site_password'] = True
+        return super().form_valid(form)
+
 
 class IndexView(LoginRequiredMixin, TemplateView):
     register_button = LinkButton('register_comp_code', 'Register')


### PR DESCRIPTION
I tested it with BETA_PASSWORD on my local .env file and it works great! So it's ready for whatever .env stuff Bryant uses with BETA_PASSWORD key :) 

DONE - Add configuration to the .env file + settings.py for the site password.
DONE - Create a new page (url, view, template) that asks for the password.
DONE - add POST logic to the view to check the password against the configuration and set request.session['site_password'] = True
DONE - Add class to middleware.py that checks for the session flag and redirects to the password page IF the session flag is not present AND there is a site password configured.
