### PR TITLE
Set up Django Error Messages

### DIFF
--- a/hifireg/registration/middleware.py
+++ b/hifireg/registration/middleware.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from django.conf import settings
+from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import resolve
 
@@ -24,6 +25,7 @@ class CheckBetaPassword:
         current_url = resolve(request.path_info).url_name
         if not current_url == 'beta_login':
             if not request.session.get('site_password') and settings.BETA_PASSWORD:
+                messages.error(request, 'Please enter the beta site password.')
                 return redirect('beta_login')
 
         response = self.get_response(request)

--- a/hifireg/registration/templates/registration/base.html
+++ b/hifireg/registration/templates/registration/base.html
@@ -114,6 +114,13 @@
             <div class="container">
                 {% block countdown %}{% endblock %}
                 <h1 class="title has-text-white">High Fidelity Registration</h1>
+                {% if messages %}
+                <div class="message is-danger messages">
+                    {% for message in messages %}
+                    <div class="message-body">{{ message }}</div>
+                    {% endfor %}
+                </div>
+                {% endif %}
                 {% block content %}
                 <div class="card">
                     <div class="card-content">

--- a/hifireg/registration/views/mixins.py
+++ b/hifireg/registration/views/mixins.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.sessions.models import Session
 from django.core.exceptions import ObjectDoesNotExist
@@ -65,6 +66,7 @@ class InvoiceRequiredMixin:
     def dispatch(self, request, *args, **kwargs):
         if self.order.invoice_set.exists():
             return super().dispatch(request, *args, **kwargs)
+        messages.error(request, 'You have no invoices to pay.')    
         return redirect('payment_plan')
 
 


### PR DESCRIPTION
- Error msg pull + bulma basic message design added to `base.html` file
- Example error message set up in the `middleware.py` file for the beta password site (note: the beta password login page initializes as a redirect so the message appears on first load)

**PLEASE NOTE for Future Use:** 
We don't add messages to the "array" as a developer | The array is hidden in the back-end magic so **_if you want to add an error message_** before a Mixin `redirect`, you'll use this and pass your string as the 2nd param: 

✅  ```  messages.error(request, 'Please enter the beta site password.') ```

**Result:** 

<img width="985" alt="Screen Shot 2020-07-19 at 4 26 58 PM" src="https://user-images.githubusercontent.com/36306993/87887914-090d2300-c9de-11ea-803c-9cbd96c74493.png">
