### PR TITLE
Redesign Product Cards

### DIFF
--- a/hifireg/registration/sass/hifi-styles.scss
+++ b/hifireg/registration/sass/hifi-styles.scss
@@ -33,6 +33,10 @@ $fullhd-enabled: false;
 // $input-border-color: transparent;
 // $input-shadow: none;
 
+$scheme-invert: black;
+$box-shadow: 0.3em 0.3em 0.3em 0.002em rgba($scheme-invert, 0.25), 0 0px 0 1.2px rgba($scheme-invert, 0.2);
+$box-padding: .75rem;
+$box-color: rgb(19, 20, 20);
 
 // TODO: only import modules that are  used
 @import "../../bulma/bulma.sass";
@@ -44,6 +48,7 @@ body {
     min-height: 100vh;
     flex-direction: column;
 }
+
 main {
     flex: 1 0 auto;
 }
@@ -165,8 +170,34 @@ main {
     .comped {
         text-decoration: line-through;
     }
+
 }
 
 .hidden-div {
     display: none;
+}
+
+input[type="checkbox"].big-checkbox {
+    -webkit-appearance:none;
+    width:20px;
+    height:20px;
+    background:white;
+    border:1px solid #555;
+    vertical-align: text-top;
+}
+
+input[type='checkbox']:checked {
+    background: rgb(166, 169, 177);
+}
+
+input[type='checkbox']:checked:after {
+    content: "✓";
+    font-size: 15px;
+    padding-left: 4px;
+    font-family: 'Zapf Dingbats';
+    vertical-align: middle;
+}
+
+.sectionHead {
+    color: black;
 }

--- a/hifireg/registration/templates/registration/product_card.html
+++ b/hifireg/registration/templates/registration/product_card.html
@@ -1,5 +1,6 @@
 {% load special_sauce %}
-<div class="column is-half">
+
+<div class="my-4">
 <div class="">
   <div data-product="{{product.id}}" data-slots="{{product.slots}}" data-max="{{product.max_quantity}}"
        class="box product-card {{product.slotClasses}} {{product.conflictClasses}}
@@ -12,7 +13,7 @@
     </div>
     {% if product.max_quantity_per_reg == 1 %}
       <div class="loader"></div>
-      <input class="check-{{product.id}} product-checkbox" type="checkbox" {% if product.status == 'max_purchased' or product.quantity_claimed > 0 %}checked{% endif %}>
+      <input class="check-{{product.id}} product-checkbox big-checkbox" type="checkbox" {% if product.status == 'max_purchased' or product.quantity_claimed > 0 %}checked{% endif %}>
     {% else %}
     <p>{{product.quantity_purchased}} already purchased.</p>
     <div class="quantity-selector">
@@ -23,14 +24,15 @@
     </div>
     {% endif %}
     {% if product.has_parts %}
-      <p>{{product.part}} of {{product.total_parts}}</p>
+      <p class="is-inline pl-3">{{product.part}} of {{product.total_parts}}</p>
     {% endif %}
-    <p>{{product.title}}</p>
-    <p>{{product.subtitle}}</p>
-    <details>
+    <p class="is-inline pl-3">{{product.title}} - </p>
+    <p class="is-inline">{{product.subtitle}}</p>
+    <p class="is-inline has-text-weight-semibold is-pulled-right {% if product.is_comped %}comped{% endif %}"><span class="has-text-weight-normal">Price: </span> {{product.price}}</p>
+    <details class="level-left pl-6">
       <p>{{product.description}}</p>
     </details>
-    <p {% if product.is_comped %}class="comped"{% endif %}>{{product.price}}</p>
+    
     {% if product.is_comped %}<p>Included with Comp</p>{% endif %}
 
   </div>

--- a/hifireg/registration/templates/registration/register_selection.html
+++ b/hifireg/registration/templates/registration/register_selection.html
@@ -6,12 +6,15 @@
 
 {% block card_content %}
 <p>Choose your {{section}}!</p>
+<!-- This line below needs to be copied and changed up for each section on the new register_products.html -->
+<p class="has-text-weight-bold sectionHead is-size-5">1. Let's get started! Select your dances:</p>
 {% for category in categories %}
   <h3 class="title">{{category.name}}</h3>
+
   <!-- Starting slots For category {{category.name}}  -->
   {% for slot in category.slots %}
     <h4 class="title is-4">{{slot.name}}</h4>
-    <div class="columns is-multiline">
+    <div class="">
       <!-- Starting products For category {{category.name}} slot {{slot.name}} -->
       {% for product in slot.products %}
         {% include 'registration/product_card.html' %}
@@ -20,7 +23,7 @@
   {% endfor %}
   
   <!-- Starting products For category {{category.name}}  -->
-  <div class="columns is-multiline">
+  <div class="">
   {% for product in category.products %}
     {% include 'registration/product_card.html' %}
   {% endfor %}


### PR DESCRIPTION
- Redesigned Product Cards to match the Wireframe as closely as possible using as much BULMA as possible
- Needed to manually override a few BULMA defaults in order to match the Wireframe (i.e. Box Shadow, etc)
- NOTE: Currently no Wireframe design for `<p>{{product.part}} of {{product.total_parts}}</p>` so left it alone, maybe you don't really need / want this to avoid UI flow disruption. 

## Images for reference: 
### Wireframe on Left | Current Output on Right

![Screen Shot 2020-08-05 at 4 00 30 PM](https://user-images.githubusercontent.com/36306993/89473087-e184bd00-d736-11ea-9b92-ca766b9e53b9.png)

### Consider removing `<p>{{product.part}} of {{product.total_parts}}</p>` to avoid UI flow disruption

![Screen Shot 2020-08-05 at 4 02 09 PM](https://user-images.githubusercontent.com/36306993/89473099-ea758e80-d736-11ea-99bf-e9567d7e1fda.png)
