### PR TITLE
Event:Figma behemoth page

### DIFF
--- a/hifireg/registration/forms/registration.py
+++ b/hifireg/registration/forms/registration.py
@@ -95,7 +95,7 @@ class RegMiscForm(forms.ModelForm):
 
 
 class RegCompCodeForm(forms.Form):
-    code = forms.CharField(label='If you have a Comp Code for a free ticket, enter it here:', max_length=CompCodeHelper.CODE_LENGTH, required=False)
+    code = forms.CharField(label='If so, please enter your comp code here:', max_length=CompCodeHelper.CODE_LENGTH, required=False)
 
     def clean(self):
         code = self.cleaned_data.get('code')

--- a/hifireg/registration/sass/hifi-styles.scss
+++ b/hifireg/registration/sass/hifi-styles.scss
@@ -71,7 +71,14 @@ main {
 // Used for the heavy client-side logic on the product selection screens
 .product-card {
 
+    transition: box-shadow 0.1s;
+    cursor: pointer;
+    &:hover {
+        box-shadow: 0.3em 0.3em 0.3em 0.002em rgba($hifi-dark-teal, 0.25), 0 0px 0 1.2px rgba($hifi-dark-teal, 0.2);
+    }
+
     &[class*="conflict-"] {
+        cursor: default;
         background: lightgrey;
         pointer-events: none;
 
@@ -87,9 +94,14 @@ main {
             content: "This conflicts with something you've selected or purchased.";
             color: red;
         }
+
+        &:hover {
+            box-shadow: $box-shadow
+        }
     }
 
     &.unavailable {
+        cursor: default;
         background: lightgrey;
         pointer-events: none;
 
@@ -105,9 +117,14 @@ main {
             content: "This item is out of stock.";
             color: red;
         }
+
+        &:hover {
+            box-shadow: $box-shadow
+        }
     }
 
     &.max-purchased {
+        cursor: default;
         background: #B0C4DE;
         pointer-events: none;
 
@@ -122,10 +139,14 @@ main {
         .error:after {
             content: "You have already purchased the maximum amount.";
         }
+
+        &:hover {
+            box-shadow: $box-shadow
+        }
     }
 
     &.claimed {
-        background: #00d1b2;
+        background: $hifi-dark-teal;
     }
 
     .quantity-selector {
@@ -154,7 +175,6 @@ main {
     .comped {
         text-decoration: line-through;
     }
-
 }
 
 .hidden-div {
@@ -184,4 +204,47 @@ input[type='checkbox'].big-checkbox:checked:after {
 
 .sectionHead {
     color: black;
+}
+
+.comp-box {
+    margin: 1.5rem 0;
+    box-shadow: 0.2em 0.2em 0.3em 0.002em rgba($scheme-invert, 0.25);
+    background-color: rgb(240, 240, 240);
+}
+
+.comp-box .field {
+    align-items: center;
+}
+
+/* using :first-child here to match specificity of a Bulma rule we want to override */
+.comp-box label:first-child {
+    margin: 0 15px 0 0;
+    font-weight: normal;
+}
+
+.comp-box .control {
+    width: 300px;
+}
+
+hr.heavy-rule {
+    height: 15px;
+    background-color: black;
+    border-radius: 7.5px;
+}
+
+.choose-ap-box {
+    background-color: $hifi-lettering;
+    border-radius: 7px;
+}
+
+.choose-ap-box button {
+    box-shadow: 0.2em 0.2em 0.3em 0.002em rgba($scheme-invert, 0.25);
+}
+
+.subtotal-box {
+    border-top: 1px solid gray;
+}
+
+.subtotal-box label {
+    margin-right: 70px;
 }

--- a/hifireg/registration/templates/registration/register_products.html
+++ b/hifireg/registration/templates/registration/register_products.html
@@ -1,0 +1,38 @@
+{% extends "registration/base.html" %}
+
+{% block countdown %}
+{% include 'registration/countdown_widget.html' %}
+{% endblock %}
+
+{% block card_content %}
+
+<p class="has-text-weight-bold sectionHead is-size-5">1. Let's get started! Select your dances:</p>
+
+{% include 'registration/register_selection.html' with selection_source=dance only %}
+
+<p class="has-text-weight-bold sectionHead is-size-5">2. Select your Workshops:</p>
+
+{% include 'registration/register_selection.html' with selection_source=class only %}
+
+<p class="has-text-weight-bold sectionHead is-size-5">3. Add on a Showcase:</p>
+
+{% include 'registration/register_selection.html' with selection_source=showcase only %}
+
+<p class="has-text-weight-bold sectionHead is-size-5">4. Grab some Swag:</p>
+
+{% include 'registration/register_selection.html' with selection_source=merch only %}
+
+
+<form method="post" novalidate>
+  {% csrf_token %}
+
+  <div class="control">
+    {% include "utils/button.html" with button=view.next_button %}
+  </div>
+</form>
+
+{% load static %}
+<script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
+<script src="{% static 'scripts/ticket_selection.js' %}"></script>
+{% endblock %}
+

--- a/hifireg/registration/templates/registration/register_products.html
+++ b/hifireg/registration/templates/registration/register_products.html
@@ -1,4 +1,5 @@
 {% extends "registration/base.html" %}
+{% load special_sauce %}
 
 {% block countdown %}
 {% include 'registration/countdown_widget.html' %}
@@ -10,35 +11,37 @@
 
 <form method="post">
   {% csrf_token %}
+
   {% include "utils/form_fields.html" %}
-  <a class="button" href="{% url 'index' %}">Previous</a>
-  <button type="submit" name='next' class="button is-primary is-pulled-right">Next</button>
-</form>
 
-<p class="has-text-weight-bold sectionHead is-size-5">1. Let's get started! Select your dances:</p>
+  <p class="has-text-weight-bold sectionHead is-size-5">1. Let's get started! Select your dances:</p>
 
-{% include 'registration/register_selection.html' with selection_source=dance only %}
+  {% include 'registration/register_selection.html' with selection_source=dance only %}
 
-<p class="has-text-weight-bold sectionHead is-size-5">2. Select your Workshops:</p>
+  <p class="has-text-weight-bold sectionHead is-size-5">2. Select your Workshops:</p>
 
-{% include 'registration/register_selection.html' with selection_source=class only %}
+  {% include 'registration/register_selection.html' with selection_source=class only %}
 
-<p class="has-text-weight-bold sectionHead is-size-5">3. Add on a Showcase:</p>
+  <p class="has-text-weight-bold sectionHead is-size-5">3. Add on a Showcase:</p>
 
-{% include 'registration/register_selection.html' with selection_source=showcase only %}
+  {% include 'registration/register_selection.html' with selection_source=showcase only %}
 
-<p class="has-text-weight-bold sectionHead is-size-5">4. Grab some Swag:</p>
+  <p class="has-text-weight-bold sectionHead is-size-5">4. Grab some Swag:</p>
 
-{% include 'registration/register_selection.html' with selection_source=merch only %}
+  {% include 'registration/register_selection.html' with selection_source=merch only %}
 
+  <p class="title">Your order total is {{ view.order.original_price|dollars }}</p>
 
-<form method="post" novalidate>
-  {% csrf_token %}
-
-  <div class="control">
-    {% include "utils/button.html" with button=view.next_button %}
+  <div class="buttons">
+    {% if view.ap_available %}
+    {% include "utils/button.html" with button=view.ap_yes_button content="AP Please" %}
+    {% else %}
+    {% include "utils/button.html" with button=view.ap_yes_button attrs="disabled" content="AP is Currently Unavailable 😢" %}
+    {% endif %}
+    {% include "utils/button.html" with button=view.ap_no_button content="Next"%}
   </div>
 </form>
+
 
 {% load static %}
 <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>

--- a/hifireg/registration/templates/registration/register_products.html
+++ b/hifireg/registration/templates/registration/register_products.html
@@ -5,6 +5,15 @@
 {% endblock %}
 
 {% block card_content %}
+<h1>Event Selection and Pricing</h1>
+<p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Repellendus temporibus numquam pariatur atque, aut saepe culpa quos reiciendis. Fuga perspiciatis ullam eos minus neque quam maiores quos rerum reprehenderit quaerat.</p>
+
+<form method="post">
+  {% csrf_token %}
+  {% include "utils/form_fields.html" %}
+  <a class="button" href="{% url 'index' %}">Previous</a>
+  <button type="submit" name='next' class="button is-primary is-pulled-right">Next</button>
+</form>
 
 <p class="has-text-weight-bold sectionHead is-size-5">1. Let's get started! Select your dances:</p>
 

--- a/hifireg/registration/templates/registration/register_products.html
+++ b/hifireg/registration/templates/registration/register_products.html
@@ -6,40 +6,81 @@
 {% endblock %}
 
 {% block card_content %}
-<h1>Event Selection and Pricing</h1>
-<p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Repellendus temporibus numquam pariatur atque, aut saepe culpa quos reiciendis. Fuga perspiciatis ullam eos minus neque quam maiores quos rerum reprehenderit quaerat.</p>
+<h1 class="title">Event Selection and Pricing</h1>
+
+<p>Dances, Classes, and more! On this page, you may choose ala carte what you'd like to attend
+  during the weekend. If you have any questions, feel free to contact us.</p>
 
 <form method="post">
   {% csrf_token %}
 
-  {% include "utils/form_fields.html" %}
+  <div class="box comp-box">
+    <p>Are you a Volunteer or Event Partner?</p>
+    {% include "utils/form_fields.html" with field_classes="is-horizontal" %}
+  </div>
 
-  <p class="has-text-weight-bold sectionHead is-size-5">1. Let's get started! Select your dances:</p>
+  <h2 class="has-text-weight-bold sectionHead is-size-5 mt-6">1. Let's get started! Select your dances:</h2>
 
   {% include 'registration/register_selection.html' with selection_source=dance only %}
 
-  <p class="has-text-weight-bold sectionHead is-size-5">2. Select your Workshops:</p>
+  <hr class="heavy-rule">
+
+  <h2 class="has-text-weight-bold sectionHead is-size-5 mt-5">2. Select your Workshops:</h2>
 
   {% include 'registration/register_selection.html' with selection_source=class only %}
 
-  <p class="has-text-weight-bold sectionHead is-size-5">3. Add on a Showcase:</p>
+  <hr class="heavy-rule">
+
+  <h2 class="has-text-weight-bold sectionHead is-size-5 mt-5">3. Add on a Showcase:</h2>
+
+  <p>Do you plan on taking part in the Showcare division? If not, you may skip this question.</p>
+
+  <p class="my-3">
+    <input id="showcase-checkbox" class="big-checkbox" type="checkbox">
+    <label for="showcase-checkbox">Yep! Sign me up!</label>
+  </p>
+
+  <p>
+    Please add your amount here for the show
+    <input type="text" class="is-pulled-right">
+  </p>
 
   {% include 'registration/register_selection.html' with selection_source=showcase only %}
 
-  <p class="has-text-weight-bold sectionHead is-size-5">4. Grab some Swag:</p>
+  <hr class="heavy-rule">
+
+  <h2 class="has-text-weight-bold sectionHead is-size-6 mt-5">4. Grab some Swag:</h2>
 
   {% include 'registration/register_selection.html' with selection_source=merch only %}
 
-  <p class="title">Your order total is {{ view.order.original_price|dollars }}</p>
-
-  <div class="buttons">
-    {% if view.ap_available %}
-    {% include "utils/button.html" with button=view.ap_yes_button content="AP Please" %}
-    {% else %}
-    {% include "utils/button.html" with button=view.ap_yes_button attrs="disabled" content="AP is Currently Unavailable 😢" %}
-    {% endif %}
-    {% include "utils/button.html" with button=view.ap_no_button content="Next"%}
+  <div class="is-clearfix is-size-4 mt-6 mb-5">
+    <div class="subtotal-box my-5 py-2 px-5 is-pulled-right">
+      <label class="has-text-weight-bold">SUBTOTAL</label>
+      <!-- TODO: This is not dynamically populating "Live" when boxes are checked or unchecked (it does if you manually reload) -->
+      {{ view.order.original_price|dollars }}
+    </div>
   </div>
+
+  <div class="choose-ap-box py-3 px-3">
+    <h2 class="has-text-weight-bold is-size-5 ">Looking great!</h2>
+    <p>Will you be needing any Affordable Pricing (AP) adjustments?</p>
+    <p>If not, please select NEXT.</p>
+
+    <div class="buttons is-right mr-6">
+      {% if view.ap_available %}
+      {% include "utils/button.html" with button=view.ap_yes_button content="AP Please" class="is-primary mr-4" %}
+      {% else %}
+      {% include "utils/button.html" with button=view.ap_yes_button attrs="disabled" content="AP is Currently Unavailable 😢" class="mr-4" %}
+      {% endif %}
+      {% include "utils/button.html" with button=view.ap_no_button content="Next" class="is-primary mr-4" %}
+    </div>
+
+    <p class="is-size-7">
+      <strong>About AP:</strong>
+      This means that if you have financial need and would not be able to pay the above price, you may apply for a discount. Payment plan options will be available later in registration whether or not you apply for Accessible Pricing. Accessible Pricing is only for adjusting your order total.
+    </p>
+  </div>
+  
 </form>
 
 

--- a/hifireg/registration/templates/registration/register_selection.html
+++ b/hifireg/registration/templates/registration/register_selection.html
@@ -1,14 +1,5 @@
-{% extends "registration/base.html" %}
 
-{% block countdown %}
-{% include 'registration/countdown_widget.html' %}
-{% endblock %}
-
-{% block card_content %}
-<p>Choose your {{section}}!</p>
-<!-- This line below needs to be copied and changed up for each section on the new register_products.html -->
-<p class="has-text-weight-bold sectionHead is-size-5">1. Let's get started! Select your dances:</p>
-{% for category in categories %}
+{% for category in selection_source.categories %}
   <h3 class="title">{{category.name}}</h3>
 
   <!-- Starting slots For category {{category.name}}  -->
@@ -30,16 +21,5 @@
   </div>
 {% endfor %}
 
-<form method="post" novalidate>
-  {% csrf_token %}
 
-  <div class="control">
-    {% include "utils/button.html" with button=view.previous_button %}
-    {% include "utils/button.html" with button=view.next_button %}
-  </div>
-</form>
 
-{% load static %}
-<script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
-<script src="{% static 'scripts/ticket_selection.js' %}"></script>
-{% endblock %}

--- a/hifireg/registration/templates/registration/register_selection.html
+++ b/hifireg/registration/templates/registration/register_selection.html
@@ -1,10 +1,8 @@
 
 {% for category in selection_source.categories %}
-  <h3 class="title">{{category.name}}</h3>
-
   <!-- Starting slots For category {{category.name}}  -->
   {% for slot in category.slots %}
-    <h4 class="title is-4">{{slot.name}}</h4>
+    <h4 class="title is-5 mt-5 pt-2 mb-0 is-uppercase">{{slot.name}}</h4>
     <div class="">
       <!-- Starting products For category {{category.name}} slot {{slot.name}} -->
       {% for product in slot.products %}

--- a/hifireg/registration/templates/utils/field_input.html
+++ b/hifireg/registration/templates/utils/field_input.html
@@ -1,6 +1,6 @@
 {% load special_sauce %}
 
-<div class="field">
+<div class="field {{field_classes}}">
 
     <label class="label" for="{{ field.id_for_label }}">{{ field.label }}</label>
     <div class="control">

--- a/hifireg/registration/urls.py
+++ b/hifireg/registration/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('register/policy/', views.RegisterPolicyView.as_view(), name='register_policy'),
 
     # must have order:
+    path('register/selection/', views.RegisterAllProductsView.as_view(), name='register_products'),
     path('register/order/', RedirectView.as_view(url=reverse_lazy('register_ticket_selection')), name='order'), # redirects to order creation view
     path('ajax/add_item/', views.AddItemView.as_view(), name='add_item'),
     path('ajax/remove_item/', views.RemoveItemView.as_view(), name='remove_item'),

--- a/hifireg/registration/urls.py
+++ b/hifireg/registration/urls.py
@@ -19,21 +19,15 @@ urlpatterns = [
     path('beta_login/', views.BetaLoginView.as_view(), name='beta_login'),
 
     # must have registration:
-    path('register/', RedirectView.as_view(url=reverse_lazy('register_comp_code')), name='registration'), # redirects to registration creation view
-    path('register/comp/', views.RegisterCompCodeView.as_view(), name='register_comp_code'),
+    path('register/', RedirectView.as_view(url=reverse_lazy('register_policy')), name='registration'), # redirects to registration creation view
     path('register/policy/', views.RegisterPolicyView.as_view(), name='register_policy'),
 
     # must have order:
     path('register/selection/', views.RegisterAllProductsView.as_view(), name='register_products'),
-    path('register/order/', RedirectView.as_view(url=reverse_lazy('register_ticket_selection')), name='order'), # redirects to order creation view
+    path('register/order/', RedirectView.as_view(url=reverse_lazy('register_products')), name='order'), # redirects to order creation view
     path('ajax/add_item/', views.AddItemView.as_view(), name='add_item'),
     path('ajax/remove_item/', views.RemoveItemView.as_view(), name='remove_item'),
-    path('register/ticket/', views.RegisterTicketSelectionView.as_view(), name='register_ticket_selection'),
-    path('register/classes/', views.RegisterClassSelectionView.as_view(), name='register_class_selection'),
-    path('register/showcase/', views.RegisterShowcaseView.as_view(), name='register_showcase'),
-    path('register/merchandise/', views.RegisterMerchandiseView.as_view(), name='register_merchandise'),
 
-    path('register/subtotal/', views.RegisterSubtotal.as_view(), name='register_subtotal'),
     path('register/accessible-pricing/', views.RegisterAccessiblePricingView.as_view(), name='register_accessible_pricing'),
     path('register/donate/', views.RegisterDonateView.as_view(), name='register_donate'),
     path('register/volunteer/', views.RegisterVolunteerView.as_view(), name='register_volunteer'),

--- a/hifireg/registration/views/mixins.py
+++ b/hifireg/registration/views/mixins.py
@@ -36,6 +36,15 @@ class PolicyRequiredMixin:
 
 
 @chain_with(PolicyRequiredMixin)
+class CreateOrderMixin:
+    def dispatch(self, request, *args, **kwargs):
+        self.order, created = Order.objects.update_or_create(
+            registration=self.registration,
+            session__isnull=False, 
+            defaults={'session': Session.objects.get(pk=request.session.session_key)})
+        return super().dispatch(request, *args, **kwargs)
+
+@chain_with(PolicyRequiredMixin)
 class OrderRequiredMixin:
     def dispatch(self, request, *args, **kwargs):
         try:
@@ -49,7 +58,7 @@ class OrderRequiredMixin:
 class NonZeroOrderRequiredMixin:
     def dispatch(self, request, *args, **kwargs):
         if not self.order.orderitem_set.exists():
-            return redirect('register_merchandise')
+            return redirect('make_payment')
         return super().dispatch(request, *args, **kwargs)
 
 

--- a/hifireg/registration/views/registration.py
+++ b/hifireg/registration/views/registration.py
@@ -114,14 +114,14 @@ class RegisterPolicyView(LoginRequiredMixin, DispatchMixin, UpdateView):
     success_url = reverse_lazy('register_products')
     previous_url = 'index'
 
-    def dispatch(self, request, *args, **kwargs):
+    def dispatch_mixin(self, request):
         try:
             self.registration = Registration.objects.get(user=request.user)
         except ObjectDoesNotExist:
             self.registration = Registration(user=request.user)
             self.registration.save()
 
-    def get_object(self, request):
+    def get_object(self):
         return self.registration
 
 

--- a/hifireg/registration/views/registration.py
+++ b/hifireg/registration/views/registration.py
@@ -150,11 +150,30 @@ class RegisterPolicyView(RegistrationRequiredMixin, UpdateView):
     template_name = 'registration/register_policy.html'
     model = Registration
     form_class = RegisterPolicyForm
-    success_url = reverse_lazy('register_ticket_selection')
-    previous_url = 'register_comp_code'
+    success_url = reverse_lazy('register_products')
+    previous_url = 'index'
 
     def get_object(self):
         return self.registration
+
+
+class RegisterAllProductsView(PolicyRequiredMixin, DispatchMixin, TemplateView):
+    template_name = 'registration/register_products.html'
+    next_button = LinkButton('register_subtotal', 'Next')
+
+
+    def dispatch_mixin(self, request):
+        order, created = Order.objects.update_or_create(
+            registration=self.registration,
+            session__isnull=False, 
+            defaults={'session': Session.objects.get(pk=request.session.session_key)})
+        
+        self.extra_context = {
+            'dance': get_context_for_product_selection(ProductCategory.DANCE, request.user),
+            'class': get_context_for_product_selection(ProductCategory.CLASS, request.user),
+            'showcase': get_context_for_product_selection(ProductCategory.SHOWCASE, request.user),
+            'merch': get_context_for_product_selection(ProductCategory.MERCH, request.user)
+        }
 
 
 class AddItemView(FunctionBasedView, View):


### PR DESCRIPTION
Hi Thena! 

**Conflict Assumption:** 
Looks like you will have some merge conflicts, but I image most of that will just be me typing _on the same line_ as someone else in the hifi-styles.css file and maybe an HTML file or two. Also, changing the the location of code by adding/deleting in the registration.py folder. But I hope it won't be too difficult to suss out. 

>Note: Please see under screenshot for Hand-off Notes/TODO's

**High-Level: What changed:**
- Refactored 5 classes to 1 class that pulls in data for the newly created/stacked `registration_products.html` which houses the new "mother load" of the Events & Items Selection Page
- Called in existing HTML's that needed to be blended onto the `registration_products` file + added manual element/content needed
- Added the merch per verbal agreement during a meeting (even though not on the Figma)
- Added a few classes in the CSS file needed to make the Event page similar to Figma using designated hifi-colors
- Used a few more Bulma existing classes to handle spacing and sizing of all the elements on the page to be similiar to Figma
- Updated various re-directs to match the suggested flow from figma in the registration.py file
- Used the hifi colors on the buttons, bottom AP div and hover per the figma design
- Maybe other things I can't think of haha xD

## SCREENSHOTS of Current Page Output with my Code vs. Figma

### Section One
![top](https://user-images.githubusercontent.com/36306993/90343036-d268ff00-dfc1-11ea-96fa-444b85ecea9a.png)

### Section Two
![middle](https://user-images.githubusercontent.com/36306993/90343047-e7de2900-dfc1-11ea-8203-97d1a2c7e4c3.png)

### Section Three
![bottom](https://user-images.githubusercontent.com/36306993/90343052-ef053700-dfc1-11ea-8676-b403df1d4f23.png)

### Hover Effect using HiFi Color
![hover](https://user-images.githubusercontent.com/36306993/90343058-ffb5ad00-dfc1-11ea-977a-e7472f79e5b8.png)

## HAND-OFF NOTES / TODOs: 

What | Description
-- | --
TODO: Bad Comp Code error message | Field error in form validation is not showing when putting in a bad Comp Code and hitting next. It does reload the page, but there’s no message to the user as to what’s going on.
Note: “AP Please” button | Currently hard coded to True for funds to make this "AP Please" button appear. When you delete it the "no ap" button will appear like on the other html page
TODO: Contact link | Wireframe has “contact us” link in heading description, but there’s no contact page I could link to that I know of
Note/TODO: Data table adjustment | In the registration_productslot table, I added the word “Friday” to the name field to produce slot output that looked like the Figma. Possible TODO: Adding a day of week column to the database table.
TODO: Dynamic Subtotal | Subtotal in the HTML is not working dynamically atm, so this needs a TODO (it does if you reload, but it doesn’t “in the moment”

**A GIANT thank you for taking this off my hands at this point and giving me a few weeks to focus on Code Fellows. I plan to see you again on September 10th team meeting!** 