### PR TITLE
Remove hard-coded ajax URLs

### DIFF
--- a/hifireg/registration/static/scripts/item_adjustments.js
+++ b/hifireg/registration/static/scripts/item_adjustments.js
@@ -11,7 +11,7 @@ $(".quantity-input").change(function() {
   thisSelector.dataset.quantity = thisSelector.value;
   if (increment > 0) {
     $.ajax({
-      url: '/registration/ajax/add_item/',
+      url: add_item_url,
       data: {
         'product': productId,
         'increment': increment
@@ -40,7 +40,7 @@ $(".quantity-input").change(function() {
   }
   if (increment < 0) {
     $.ajax({
-      url: '/registration/ajax/remove_item/',
+      url: remove_item_url,
       data: {
         'product': productId,
         'decrement': increment * -1

--- a/hifireg/registration/static/scripts/ticket_selection.js
+++ b/hifireg/registration/static/scripts/ticket_selection.js
@@ -35,7 +35,7 @@ $(".product-checkbox").change(function() {
 
   if (this.checked) {
     $.ajax({
-      url: '/registration/ajax/add_item/',
+      url: add_item_url,
       data: {
         'product': productId,
         'increment': 1
@@ -69,7 +69,7 @@ $(".product-checkbox").change(function() {
     });
   } else {
     $.ajax({
-      url: '/registration/ajax/remove_item/',
+      url: remove_item_url,
       data: {
         'product': productId,
         'decrement': 1
@@ -112,7 +112,7 @@ $(".quantity-input").change(function() {
   thisSelector.dataset.quantity = thisSelector.value;
   if (increment > 0) {
     $.ajax({
-      url: '/registration/ajax/add_item/',
+      url: add_item_url,
       data: {
         'product': productId,
         'increment': increment
@@ -146,7 +146,7 @@ $(".quantity-input").change(function() {
   }
   if (increment < 0) {
     $.ajax({
-      url: '/registration/ajax/remove_item/',
+      url: remove_item_url,
       data: {
         'product': productId,
         'decrement': increment * -1

--- a/hifireg/registration/templates/registration/payment.html
+++ b/hifireg/registration/templates/registration/payment.html
@@ -79,5 +79,6 @@
 <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
 <script src="https://js.stripe.com/v3/"></script>
 <script src="{% static 'scripts/checkout.js' %}"></script>
+{% include "scripts/ajax_urls.js.html" %}
 <script src="{% static 'scripts/item_adjustments.js' %}"></script>
 {% endblock %}

--- a/hifireg/registration/templates/registration/register_products.html
+++ b/hifireg/registration/templates/registration/register_products.html
@@ -86,6 +86,6 @@
 
 {% load static %}
 <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
+{% include "scripts/ajax_urls.js.html" %}
 <script src="{% static 'scripts/ticket_selection.js' %}"></script>
 {% endblock %}
-

--- a/hifireg/registration/templates/scripts/ajax_urls.js.html
+++ b/hifireg/registration/templates/scripts/ajax_urls.js.html
@@ -1,0 +1,5 @@
+<script>
+'use strict';
+const add_item_url = '{% url "add_item" %}';
+const remove_item_url = '{% url "remove_item" %}';
+</script>


### PR DESCRIPTION
My attempt to remove hard-coded URLs from AJAX.
Alternatively, we just move the entire javascript file into the template directory and then include it in a similar manner, but I liked the idea of most of the file being static and passing global vars dynamically... but that might be too convoluted and not have any real impact on performance. 