### PR TITLE
Added | Dynamic subtotal on selection page

### DIFF
--- a/hifireg/registration/static/scripts/checkout.js
+++ b/hifireg/registration/static/scripts/checkout.js
@@ -1,10 +1,3 @@
-function dollars(value) {
-  value = value * 0.01;
-  value = value.toLocaleString(undefined, {
-    'minimumFractionDigits':2, 'maximumFractionDigits':2
-  });
-  return "$" + value;
-};
 
 
 // when click checkout button

--- a/hifireg/registration/static/scripts/helpers.js
+++ b/hifireg/registration/static/scripts/helpers.js
@@ -1,0 +1,8 @@
+
+// converts total amount to dollars at top of page | No commas per senior dev request
+function dollars(value) {
+  value = value * 0.01;
+  value = value.toFixed(2);
+  return "$" + value;
+};
+

--- a/hifireg/registration/static/scripts/invoices.js
+++ b/hifireg/registration/static/scripts/invoices.js
@@ -89,12 +89,7 @@
     return amount;
   };
 
-  // converts total amount to dollars at top of page
-  function dollars(value) {
-    value = value * 0.01;
-    value = value.toFixed(2);
-    return "$" + value;
-  };
+
   
   // AJAX (for brevity sake) request to Stripe API
   payInvoicesButton.onclick = function(e){

--- a/hifireg/registration/static/scripts/ticket_selection.js
+++ b/hifireg/registration/static/scripts/ticket_selection.js
@@ -1,3 +1,6 @@
+
+
+
 //product-card clicks can togggle checkbox
 $('.product-card').on('click', function(e) {
   //if this is not a checkbox card, move on
@@ -53,7 +56,9 @@ $(".product-checkbox").change(function() {
             conflicts.addClass(`conflict-${slot}`);
           });
           parents.addClass('claimed');
-
+          var newTotal = dollars(data.newTotalInCents);
+          $('#subtotal').text(newTotal);
+          
         } else {
           resetCountDown();
           checkBoxes.prop('checked', false);
@@ -85,6 +90,8 @@ $(".product-checkbox").change(function() {
 
           $('.product-card').removeClass('call-in-progress');
           parents.removeClass('loading claimed');
+          var newTotal = dollars(data.newTotalInCents);
+          $('#subtotal').text(newTotal);
         }
       },
       error: function (xhr, status, error) {
@@ -128,6 +135,8 @@ $(".quantity-input").change(function() {
             conflicts.addClass(`conflict-${slot}`);
           });
           parent.addClass('claimed');
+          var newTotal = dollars(data.newTotalInCents);
+          $('#subtotal').text(newTotal);
 
         } else {
           location.reload();
@@ -162,6 +171,8 @@ $(".quantity-input").change(function() {
 
           $('.product-card').removeClass('call-in-progress');
           parent.removeClass('loading');
+          var newTotal = dollars(data.newTotalInCents);
+          $('#subtotal').text(newTotal);
         }
       },
       error: function (xhr, status, error) {

--- a/hifireg/registration/templates/registration/base.html
+++ b/hifireg/registration/templates/registration/base.html
@@ -16,6 +16,7 @@
 
     <!-- Bulma js implementation -->
     <script src="{% static "scripts/bulma-impl.js" %}"></script>
+   
 
 </head>
 

--- a/hifireg/registration/templates/registration/invoices.html
+++ b/hifireg/registration/templates/registration/invoices.html
@@ -59,6 +59,7 @@
 <script src="https://js.stripe.com/v3/"></script>
 
 {% include "scripts/ajax_urls.js.html" %}
+<script src="{% static 'scripts/helpers.js' %}"></script>
 <script src="{% static 'scripts/invoices.js' %}"></script>
 
 {% endblock %}

--- a/hifireg/registration/templates/registration/payment.html
+++ b/hifireg/registration/templates/registration/payment.html
@@ -80,6 +80,7 @@
 <script src="https://js.stripe.com/v3/"></script>
 
 {% include "scripts/ajax_urls.js.html" %}
+<script src="{% static 'scripts/helpers.js' %}"></script>
 <script src="{% static 'scripts/checkout.js' %}"></script>
 <script src="{% static 'scripts/item_adjustments.js' %}"></script>
 {% endblock %}

--- a/hifireg/registration/templates/registration/register_products.html
+++ b/hifireg/registration/templates/registration/register_products.html
@@ -56,8 +56,7 @@
   <div class="is-clearfix is-size-4 mt-6 mb-5">
     <div class="subtotal-box my-5 py-2 px-5 is-pulled-right">
       <label class="has-text-weight-bold">SUBTOTAL</label>
-      <!-- TODO: This is not dynamically populating "Live" when boxes are checked or unchecked (it does if you manually reload) -->
-      {{ view.order.original_price|dollars }}
+      <span id="subtotal">{{ view.order.original_price|dollars }}</span>
     </div>
   </div>
 
@@ -87,5 +86,6 @@
 {% load static %}
 <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
 {% include "scripts/ajax_urls.js.html" %}
+<script src="{% static 'scripts/helpers.js' %}"></script>
 <script src="{% static 'scripts/ticket_selection.js' %}"></script>
 {% endblock %}

--- a/hifireg/registration/views/helpers.py
+++ b/hifireg/registration/views/helpers.py
@@ -65,13 +65,14 @@ def add_quantity_range_to_item(item):
     item.quantity_range = range(0, min(item.product.max_quantity_per_reg - item.quantity_purchased, item.product.available_quantity + item.quantity) + 1)
     return item
 
-def add_remove_item_view(request, action):
+def add_remove_item_view(request, order, action):
     try:
         product_id = request.POST['product']
         success = action(product_id, int(request.POST['quantity']))
         
         data = {
             'success': success,
+            'newTotalInCents': order.original_price,
         }
     except Exception as e:
         data = {

--- a/hifireg/registration/views/registration.py
+++ b/hifireg/registration/views/registration.py
@@ -221,12 +221,12 @@ class RegisterAllProductsView(CreateOrderMixin, FormView):
 
 class AddItemView(OrderRequiredMixin, View):
     def post(self, request):
-        return add_remove_item_view(request, self.order.add_item)
+        return add_remove_item_view(request, self.order, self.order.add_item)
 
 
 class RemoveItemView(OrderRequiredMixin, View):
     def post(self, request):
-        return add_remove_item_view(request, self.order.remove_item)
+        return add_remove_item_view(request, self.order, self.order.remove_item)
 
 
 class RegisterAccessiblePricingView(NonZeroOrderRequiredMixin, DispatchMixin, TemplateView):


### PR DESCRIPTION
- Quick Fix | added "," to the special_sauce dollars helper for continuity over $999
- Added | new data prop called newTotalInCents in add_remove_item_view on helpers.py
- Added | a new param (used as 2nd param) to add_remove_item_view function from helpers.py. and added the value self.order for it on reg.py
- Added | functionality accessing data.newTotalInCents to ticket_selection.js for all add/remove checkbox and option tags and converted cents to dollars for render
- Added | span tag with ID for access for dynamic subtotal change on register_products.html
