### PR TITLE
Added | Prev btn to selection page

### DIFF
--- a/hifireg/registration/templates/registration/register_products.html
+++ b/hifireg/registration/templates/registration/register_products.html
@@ -64,15 +64,14 @@
   <div class="choose-ap-box py-3 px-3">
     <h2 class="has-text-weight-bold is-size-5 ">Looking great!</h2>
     <p>Will you be needing any Affordable Pricing (AP) adjustments?</p>
-    <p>If not, please select NEXT.</p>
+    <p>If not, please select the Next button.</p>
 
-    <div class="buttons is-right mr-6">
+    <div class="buttons is-right mr-1">
       {% if view.ap_available %}
       {% include "utils/button.html" with button=view.ap_yes_button content="AP Please" class="is-primary mr-4" %}
       {% else %}
       {% include "utils/button.html" with button=view.ap_yes_button attrs="disabled" content="AP is Currently Unavailable 😢" class="mr-4" %}
       {% endif %}
-      {% include "utils/button.html" with button=view.ap_no_button content="Next" class="is-primary mr-4" %}
     </div>
 
     <p class="is-size-7">
@@ -81,6 +80,12 @@
     </p>
   </div>
   
+  <div class="control mt-5">
+    {% include "utils/button.html" with button=view.previous_button %}
+
+    {% include "utils/button.html" with button=view.ap_no_button content="Next" class="is-primary is-pulled-right" %}
+  </div>
+
 </form>
 
 

--- a/hifireg/registration/views/registration.py
+++ b/hifireg/registration/views/registration.py
@@ -173,6 +173,7 @@ class RegisterFormsView(RegistrationRequiredMixin, TemplateView):
 class RegisterAllProductsView(CreateOrderMixin, FormView):
     template_name = 'registration/register_products.html'
     form_class = RegCompCodeForm
+    previous_button = SubmitButton('Previous')
     ap_yes_button = SubmitButton('claim_ap')
     ap_no_button = SubmitButton('not_ap')
 


### PR DESCRIPTION
- Added Prev btn to the selection product page
- Pulled the Next btn out of the AP box per group discussion on Thursday
- Floated them a part like on other pages


<img width="963" alt="Screen Shot 2020-09-21 at 6 07 36 PM" src="https://user-images.githubusercontent.com/36306993/93835857-8733b300-fc35-11ea-9c1c-3c98fef3e99c.png">
