### PR TITLE
Fixed | Removed Showcase Fixed Prev button

### DIFF
--- a/hifireg/registration/templates/registration/register_products.html
+++ b/hifireg/registration/templates/registration/register_products.html
@@ -31,24 +31,6 @@
 
   <hr class="heavy-rule">
 
-  <h2 class="has-text-weight-bold sectionHead is-size-5 mt-5">3. Add on a Showcase:</h2>
-
-  <p>Do you plan on taking part in the Showcare division? If not, you may skip this question.</p>
-
-  <p class="my-3">
-    <input id="showcase-checkbox" class="big-checkbox" type="checkbox">
-    <label for="showcase-checkbox">Yep! Sign me up!</label>
-  </p>
-
-  <p>
-    Please add your amount here for the show
-    <input type="text" class="is-pulled-right">
-  </p>
-
-  {% include 'registration/register_selection.html' with selection_source=showcase only %}
-
-  <hr class="heavy-rule">
-
   <h2 class="has-text-weight-bold sectionHead is-size-6 mt-5">4. Grab some Swag:</h2>
 
   {% include 'registration/register_selection.html' with selection_source=merch only %}

--- a/hifireg/registration/views/registration.py
+++ b/hifireg/registration/views/registration.py
@@ -192,6 +192,12 @@ class RegisterAllProductsView(FormsRequiredMixin, DispatchMixin, FormView):
         elif self.ap_no_button.name in self.request.POST:
             self.order.revoke_accessible_pricing()
             return reverse('register_donate')
+        
+        elif self.previous_button.name in self.request.POST:
+            if not self.registration.is_submitted:
+                return reverse('register_forms')
+            else: 
+                return reverse('index')
 
     def get_initial(self):
         return {


### PR DESCRIPTION
- Did ONE Branch/PR since the removal of a section was super tiny and on the same page as prev button bug fix 
- Removed showcase section 
- Added logic for when click Prev on selection page - if you have previous purchased orders, it takes you back to your index (which is the current order that exists) and if it's a new registration it takes you back to forms (which looks like comes after policy but before product selection)

- I added a bug asana card to Asana which is a separate issue I found when testing Prev button. 